### PR TITLE
Feat google login

### DIFF
--- a/battle/urls.py
+++ b/battle/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
-from battle.views import battle
+from battle.views import battle, choose, not_authenticated
 
 
 urlpatterns = [
     path('battle/', battle, name='battle'),
+    path('choose/', choose, name='choose'),
+    path('not_authenticated/', not_authenticated, name='not_authenticated')
 ]

--- a/battle/views.py
+++ b/battle/views.py
@@ -16,6 +16,9 @@ def battle(request):
 @login_required(login_url='/not_authenticated')
 def choose(request):
     #print(request.user)  # getting the user in order to retrieve data from database
+
+    # note: we can add code to retrieve token here
+    # there will be a json instead of the following message
     return HttpResponse('I can see this because I am logged in', status=200)
 
 

--- a/battle/views.py
+++ b/battle/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 import json
 from django.http import HttpResponse
+from django.contrib.auth.decorators import login_required
 
 TEST_JSON = '{"winner":True,"army":{"S":0,"C":1,"D":2},"report":{1:{"a":3,"d":1},2:{"a":2,"d":1}}}'
 
@@ -9,5 +10,16 @@ def battle(request):
     #json_str = request.POST.get('data', '')
     return HttpResponse(TEST_JSON, status=200, content_type='application/json')
 
+
+# the following (test) code is accessible only if the user is already logged in
+# if the user is not logged in, they will be displayed an unauthorized message (401)
+@login_required(login_url='/not_authenticated')
+def choose(request):
+    #print(request.user)  # getting the user in order to retrieve data from database
+    return HttpResponse('I can see this because I am logged in', status=200)
+
+
+def not_authenticated(request):
+    return HttpResponse('not authorized: please sign in', status=401)
 
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -17,6 +17,19 @@ import django_heroku
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# the following is needed in order to directly save email (unique) in db after Google Login
+ACCOUNT_USERNAME_REQUIRED = True
+ACCOUNT_EMAIL_REQUIRED = True
+SOCIALACCOUNT_EMAIL_REQUIRED = False
+SOCIALACCOUNT_QUERY_EMAIL = True
+
+SOCIALACCOUNT_PROVIDERS = \
+    {
+        'google': {
+            'SCOPE': ['profile','email'],
+            'AUTH_PARAMS': {'access_type': 'online'}
+        }
+    }
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/

--- a/core/settings.py
+++ b/core/settings.py
@@ -40,7 +40,18 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'corsheaders',  # added
-    'battle',  # added
+    'django.contrib.sites',  # added
+
+    # local
+    'battle',
+
+    # allauth
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+
+    # providers
+    'allauth.socialaccount.providers.google',
 ]
 
 MIDDLEWARE = [
@@ -131,5 +142,7 @@ STATIC_URL = '/static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+SITE_ID = 1
 
 django_heroku.settings(locals())

--- a/core/urls.py
+++ b/core/urls.py
@@ -20,4 +20,5 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('battle.urls')),
+    path('accounts/', include('allauth.urls')),
 ]


### PR DESCRIPTION
- added google provider in settings and site ID 1 added
- email required (automatically added to db)
- /accounts/google/login activated
- /choose/ API post-login with login required decorator
- /not_authenticated/ API added with 401 messate