### PR TITLE
Temp no login required (with temporary token exchange in url)

### DIFF
--- a/army/army_package/army_for_test.py
+++ b/army/army_package/army_for_test.py
@@ -1,0 +1,32 @@
+import random
+
+
+def generate_random_army():  # returns random combinations of troups with a value of 30
+    s_price = 5
+    c_price = 2
+    d_price = 1
+    budget = 30
+    # type of troups are S,C,D
+    # at least one per each type is needed
+    s = random.choice([1, 2, 3, 4, 5])
+    if s == 5:  # note that maximum s type troups is 5 since 6*2_price = 30 and there would be no budget left
+        c = random.choice([1, 2])
+    elif s == 4:
+        c = random.choice([1, 2, 3, 4])
+    elif s == 3:
+        c = random.choice([1, 2, 3, 4, 5, 6, 7])
+    elif s == 2:
+        c = random.choice([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    elif s == 1:
+        c = random.choice([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+    d = budget - (s * s_price + c * c_price)  # the rest of the budget is spent for d type troups
+
+    f = random.choice([1, 2, 3])  # strategy
+
+    army = {"S": s, "C": c, "D": d, "F": f}
+    return army
+
+
+if __name__ == '__main__':
+    print(generate_random_army())
+

--- a/battle/urls.py
+++ b/battle/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from battle.views import battle, choose, not_authenticated, index, battle_temp, choose_temp
+from battle.views import battle, choose, not_authenticated, index, battle_temp, choose_temp, user_logged_in_
 
 
 urlpatterns = [
@@ -10,4 +10,7 @@ urlpatterns = [
 
     path('battletemp/', battle_temp, name='battle_temp'),
     path('choosetemp/', choose_temp, name='choose_temp'),
+
+    path('oauth/', user_logged_in_),  # used to trigger view that retrieves auth data
+
 ]

--- a/battle/views.py
+++ b/battle/views.py
@@ -29,7 +29,7 @@ def index(request):
 
 # if the user is not logged in, they will be displayed an unauthorized message (401)
 # @csrf_exempt
-@login_required(login_url='/not_authenticated')
+#@login_required(login_url='/not_authenticated')
 def battle(request):
     """
     # in case FE temporarily does not send us the JSON (test code)
@@ -104,15 +104,15 @@ def choose(request):
     if not request.method == 'GET':
         return HttpResponseBadRequest("Bad request")
     ### test code ###
-    # data = {'username': 'fake user',
-    #         'token': 'fake_142524523515fjgnjdgn',
-    #         'prices': {'S': 5, 'C': 2, 'D': 1},
-    #         "F": [1, 2, 3],
-    #         'budget': 30,
-    #         'planets': ['Earth', 'Jupiter', 'Mars', 'Mercury', 'Neptune', 'Saturn', 'Uranus', 'Venus']}
-    #         #################
-    # data_as_json = json.dumps(data)
-    # return HttpResponse(data_as_json, status=200, content_type='application/json')
+    data = {'username': 'fake user',
+            'token': 'fake_142524523515fjgnjdgn',
+            'prices': {'S': 5, 'C': 2, 'D': 1},
+            "F": [1, 2, 3],
+            'budget': 30,
+            'planets': ['Earth', 'Jupiter', 'Mars', 'Mercury', 'Neptune', 'Saturn', 'Uranus', 'Venus']}
+            #################
+    data_as_json = json.dumps(data)
+    return HttpResponse(data_as_json, status=200, content_type='application/json')
 
     user_auth = UserAuth(request)
     '''

--- a/battle/views.py
+++ b/battle/views.py
@@ -26,7 +26,7 @@ def index(request):
 
 
 # if the user is not logged in, they will be displayed an unauthorized message (401)
-@login_required(login_url='/not_authenticated')
+#@login_required(login_url='/not_authenticated')
 def battle(request):
     """
     # in case FE temporarily does not send us the JSON (test code)
@@ -87,7 +87,7 @@ def battle_temp(request):  # does not require login (useful for FE tests)
 
 
 # if the user is not logged in, they will be displayed an unauthorized message (401)
-@login_required(login_url='/not_authenticated')
+#@login_required(login_url='/not_authenticated')
 def choose(request):
     if not request.method == 'GET':
         return HttpResponseBadRequest("Bad request")

--- a/battle/views.py
+++ b/battle/views.py
@@ -98,7 +98,7 @@ def battle_temp(request):  # does not require login (useful for FE tests)
 
 
 # if the user is not logged in, they will be displayed an unauthorized message (401)
-@login_required(login_url='/not_authenticated')
+#@login_required(login_url='/not_authenticated')
 def choose(request):
     print(request.headers)
     if not request.method == 'GET':

--- a/battle/views.py
+++ b/battle/views.py
@@ -98,7 +98,7 @@ def battle_temp(request):  # does not require login (useful for FE tests)
 
 
 # if the user is not logged in, they will be displayed an unauthorized message (401)
-@login_required(login_url='/not_authenticated')
+#@login_required(login_url='/not_authenticated')
 def choose(request):
     if not request.method == 'GET':
         return HttpResponseBadRequest("Bad request")

--- a/battle/views.py
+++ b/battle/views.py
@@ -46,6 +46,7 @@ def battle(request):
     #print(json_request)  # incoming request for the battle
     #print()
     if json_request["defender"]["army"] and json_request["attacker"]["army"]:
+        planets = [json_request["attacker"]["planet"], json_request["defender"]["planet"]]
         # temporarily overwriting sent defender's army !
         random_defender_army = generate_random_army()
         initial_d_army = copy.deepcopy(random_defender_army)  # copied because it will be added to thi final json
@@ -61,6 +62,7 @@ def battle(request):
         battle_response_as_json = json.loads(battle_response)
         battle_response_as_json["init_d_army"] = initial_d_army  # initial defender army
         battle_response_as_json["init_a_army"] = initial_a_army  # initial attacker army
+        battle_response_as_json["planets"] = planets  # first is attacker's planet, second is defender's
         battle_response_final = json.dumps(battle_response_as_json)
         print()
         print(battle_response)

--- a/battle/views.py
+++ b/battle/views.py
@@ -91,6 +91,17 @@ def battle_temp(request):  # does not require login (useful for FE tests)
 def choose(request):
     if not request.method == 'GET':
         return HttpResponseBadRequest("Bad request")
+    ### test code ###
+    data = {'username': 'fake user',
+            'token': 'fake_142524523515fjgnjdgn',
+            'prices': {'S': 5, 'C': 2, 'D': 1},
+            "F": [1, 2, 3],
+            'budget': 30,
+            'planets': ['Earth', 'Jupiter', 'Mars', 'Mercury', 'Neptune', 'Saturn', 'Uranus', 'Venus']}
+            #################
+    data_as_json = json.dumps(data)
+    return HttpResponse(data_as_json, status=200, content_type='application/json')
+
     user_auth = UserAuth(request)
     '''
     # print(request.user)

--- a/battle/views.py
+++ b/battle/views.py
@@ -44,11 +44,12 @@ def battle(request):
         return HttpResponseBadRequest("Bad request")
     json_request = json.loads(request.body)
     #print(json_request)  # incoming request for the battle
-    print()
-    if json_request["defender"]["army"]:
+    #print()
+    if json_request["defender"]["army"] and json_request["attacker"]["army"]:
         # temporarily overwriting sent defender's army !
         random_defender_army = generate_random_army()
         initial_d_army = copy.deepcopy(random_defender_army)  # copied because it will be added to thi final json
+        initial_a_army = copy.deepcopy(json_request["attacker"]["army"])
         json_request["defender"]["army"] = random_defender_army  # an army with an overall value of 30 is returned
         ##############################################
         print(json_request)  # updated battle request (the defender army is overwritten by BE)
@@ -58,7 +59,8 @@ def battle(request):
         battle_response = response.battle_final_report
         # temporarily adding the initial defender army inside the battle response
         battle_response_as_json = json.loads(battle_response)
-        battle_response_as_json["init_d_army"] = initial_d_army
+        battle_response_as_json["init_d_army"] = initial_d_army  # initial defender army
+        battle_response_as_json["init_a_army"] = initial_a_army  # initial attacker army
         battle_response_final = json.dumps(battle_response_as_json)
         print()
         print(battle_response)

--- a/battle/views.py
+++ b/battle/views.py
@@ -98,7 +98,7 @@ def battle_temp(request):  # does not require login (useful for FE tests)
 
 
 # if the user is not logged in, they will be displayed an unauthorized message (401)
-#@login_required(login_url='/not_authenticated')
+@login_required(login_url='/not_authenticated')
 def choose(request):
     if not request.method == 'GET':
         return HttpResponseBadRequest("Bad request")

--- a/battle/views.py
+++ b/battle/views.py
@@ -41,13 +41,14 @@ def battle(request):
    """
     if not (request.method == 'POST'):
         return HttpResponseBadRequest("Bad request")
-
     json_request = json.loads(request.body)
     print(json_request)
+    print()
     if json_request["defender"]["army"]:
         # temporarily overwriting sent defender's army !
         json_request["defender"]["army"] = generate_random_army()  # an army with an overall value of 30 is returned
         ##############################################
+        print(json_request)
         battle_request = Request(json_request)  # a dictionary is passed to the Request
         current_battle = Battle(battle_request)
 

--- a/battle/views.py
+++ b/battle/views.py
@@ -42,6 +42,7 @@ def battle(request):
         return HttpResponseBadRequest("Bad request")
 
     json_request = json.loads(request.body)
+    print(json_request)
     if json_request["defender"]["army"]:
         battle_request = Request(json_request)  # a dictionary is passed to the Request
         current_battle = Battle(battle_request)

--- a/battle/views.py
+++ b/battle/views.py
@@ -6,6 +6,7 @@ from .battle_package.request import Request
 from .battle_package.response import Response
 from .battle_package.algorithm import Battle
 from army.army_package.army import SpaceShip, SpaceCruiser, SpaceDestroyer
+from django.views.decorators.csrf import csrf_exempt
 
 
 # TEST_JSON = '{"winner":true,"army":{"S":0,"C":1,"D":2},"report":{"1":{"a":3,"d":1},"2":{"a":2,"d":1}}}'
@@ -26,6 +27,7 @@ def index(request):
 
 
 # if the user is not logged in, they will be displayed an unauthorized message (401)
+# @csrf_exempt
 #@login_required(login_url='/not_authenticated')
 def battle(request):
     """
@@ -40,12 +42,15 @@ def battle(request):
         return HttpResponseBadRequest("Bad request")
 
     json_request = json.loads(request.body)
-    battle_request = Request(json_request)  # a dictionary is passed to the Request
-    current_battle = Battle(battle_request)
+    if json_request["defender"]["army"]:
+        battle_request = Request(json_request)  # a dictionary is passed to the Request
+        current_battle = Battle(battle_request)
 
-    response = Response(current_battle)  # OBJ type Response
-    battle_response = response.battle_final_report
-    return HttpResponse(battle_response, status=200, content_type='application/json')
+        response = Response(current_battle)  # OBJ type Response
+        battle_response = response.battle_final_report
+        return HttpResponse(battle_response, status=200, content_type='application/json')
+    else:
+        return HttpResponseBadRequest("Bad request")
 
 
 def battle_temp(request):  # does not require login (useful for FE tests)

--- a/battle/views.py
+++ b/battle/views.py
@@ -29,7 +29,7 @@ def index(request):
 
 # if the user is not logged in, they will be displayed an unauthorized message (401)
 # @csrf_exempt
-#@login_required(login_url='/not_authenticated')
+@login_required(login_url='/not_authenticated')
 def battle(request):
     """
     # in case FE temporarily does not send us the JSON (test code)
@@ -98,9 +98,9 @@ def battle_temp(request):  # does not require login (useful for FE tests)
 
 
 # if the user is not logged in, they will be displayed an unauthorized message (401)
-#@login_required(login_url='/not_authenticated')
+@login_required(login_url='/not_authenticated')
 def choose(request):
-    print(request)
+    print(request.headers)
     if not request.method == 'GET':
         return HttpResponseBadRequest("Bad request")
     ### test code ###

--- a/battle/views.py
+++ b/battle/views.py
@@ -100,6 +100,7 @@ def battle_temp(request):  # does not require login (useful for FE tests)
 # if the user is not logged in, they will be displayed an unauthorized message (401)
 #@login_required(login_url='/not_authenticated')
 def choose(request):
+    print(request)
     if not request.method == 'GET':
         return HttpResponseBadRequest("Bad request")
     ### test code ###

--- a/battle/views.py
+++ b/battle/views.py
@@ -6,6 +6,7 @@ from .battle_package.request import Request
 from .battle_package.response import Response
 from .battle_package.algorithm import Battle
 from army.army_package.army import SpaceShip, SpaceCruiser, SpaceDestroyer
+from army.army_package.army_for_test import generate_random_army
 from django.views.decorators.csrf import csrf_exempt
 
 
@@ -44,6 +45,9 @@ def battle(request):
     json_request = json.loads(request.body)
     print(json_request)
     if json_request["defender"]["army"]:
+        # temporarily overwriting sent defender's army !
+        json_request["defender"]["army"] = generate_random_army()  # an army with an overall value of 30 is returned
+        ##############################################
         battle_request = Request(json_request)  # a dictionary is passed to the Request
         current_battle = Battle(battle_request)
 

--- a/battle/views.py
+++ b/battle/views.py
@@ -1,5 +1,5 @@
 import json
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
 from django.contrib.auth.decorators import login_required
 from authentication.authentication_package.auth_data import UserAuth  # check this import
 from .battle_package.request import Request
@@ -9,18 +9,9 @@ from army.army_package.army import SpaceShip, SpaceCruiser, SpaceDestroyer
 from army.army_package.army_for_test import generate_random_army
 from django.views.decorators.csrf import csrf_exempt
 import copy
-
-
-# TEST_JSON = '{"winner":true,"army":{"S":0,"C":1,"D":2},"report":{"1":{"a":3,"d":1},"2":{"a":2,"d":1}}}'
-# input_fe = '{"attacker":{"type":"human",' \
-#           '"name":"player x",' \
-#           '"mail":"player@mail.com",' \
-#           '"army":{"S":24,"C":1,"D":1,"F":1},' \
-#           '"planet":"Venus"},' \
-#           '"defender":{"type":"virtual",' \
-#           '"name":"computer 1",' \
-#           '"army":{"S":7,"C":8,"D":9,"F":2},' \
-#           '"planet":"Mercury"}}'
+from django.dispatch.dispatcher import receiver
+from allauth.account.signals import user_logged_in
+from django.shortcuts import redirect
 
 
 def index(request):
@@ -28,9 +19,22 @@ def index(request):
     return HttpResponse(message, status=200)
 
 
+# the following view would serve just for sending to the FE the oAuth data directly after authentication
+# when the FE receives them, it can call our /choose/ API but with permissions
+@receiver(user_logged_in, dispatch_uid="unique")
+def user_logged_in_(request, **kwargs):  # this view is able to automatically detect the logged in user
+    print(request.user)
+    user_auth = UserAuth(request)
+    append = "?=" + user_auth.token  # this will append the token to the url (temporary solution)
+    return redirect("https://browsergameteam2.netlify.app/battle__page" + append)
+    # the following is an attempt to set cookies or place token inside the headers (instead of appending to the URL)
+    # response.set_cookie('cookie_name', 'cookie_value', max_age=1000)
+    # response = HttpResponseRedirect('https://browsergameteam2.netlify.app/battle__page')
+    # response['X-Auth-Token'] = user_auth.token
+    # return response
+
+
 # if the user is not logged in, they will be displayed an unauthorized message (401)
-# @csrf_exempt
-#@login_required(login_url='/not_authenticated')
 def battle(request):
     """
     # in case FE temporarily does not send us the JSON (test code)
@@ -43,9 +47,9 @@ def battle(request):
     if not (request.method == 'POST'):
         return HttpResponseBadRequest("Bad request")
     json_request = json.loads(request.body)
-    #print(json_request)  # incoming request for the battle
+    #print(json_request)  # incoming request for the battle  (with a bugged defender's army)
     #print()
-    if json_request["defender"]["army"] and json_request["attacker"]["army"]:
+    if json_request["attacker"]["army"]:
         planets = [json_request["attacker"]["planet"], json_request["defender"]["planet"]]
         # temporarily overwriting sent defender's army !
         random_defender_army = generate_random_army()
@@ -70,6 +74,59 @@ def battle(request):
         return HttpResponse(battle_response_final, status=200, content_type='application/json')
     else:
         return HttpResponseBadRequest("Bad request")
+
+
+def not_authenticated(request):
+    return HttpResponse('not authorized: please sign in', status=401)
+
+
+# if the user is not logged in, they will be displayed an unauthorized message (401)
+def choose(request):
+    print(request.headers)
+    if not request.method == 'GET':
+        return HttpResponseBadRequest("Bad request")
+    ### TEST CODE, when we manage to handle permission this will have to be deleted until line 132 ###
+    data = {'username': 'fake user',
+            'token': 'fake_142524523515fjgnjdgn',
+            'prices': {'S': 5, 'C': 2, 'D': 1},
+            "F": [1, 2, 3],
+            'budget': 30,
+            'planets': ['Earth', 'Jupiter', 'Mars', 'Mercury', 'Neptune', 'Saturn', 'Uranus', 'Venus']}
+            #################
+    data_as_json = json.dumps(data)
+    return HttpResponse(data_as_json, status=200, content_type='application/json')
+    ##### END OF TEST CODE
+
+    user_auth = UserAuth(request)
+    '''
+    # print(request.user)
+    # note: the request.user value is always unique! Thus it can be directly used to retrieve token from db
+    '''
+    data = {'username': user_auth.username,
+            'token': user_auth.token,
+            'uid': user_auth.uid,
+            'prices': {"S": SpaceShip().price, "C": SpaceCruiser().price, "D": SpaceDestroyer().price},
+            "F": [1, 2, 3],
+            'budget': 30,
+            'planets': ['Earth', 'Jupiter', 'Mars', 'Mercury', 'Neptune', 'Saturn', 'Uranus', 'Venus']
+            }
+    data_as_json = json.dumps(data)
+    return HttpResponse(data_as_json, status=200, content_type='application/json')
+
+
+# the following are TEMP APIs for testing purpose
+
+def choose_temp(request):  # does not require login (useful for FE tests)
+    data = {'username': "fake user",
+            'token': "abcd.FAKETOKENnafk48598258gnfmn43849gnfureufjjurjru383574n3jkf",
+            'prices': {"S": SpaceShip().price, "C": SpaceCruiser().price, "D": SpaceDestroyer().price},
+            "F": [1, 2, 3],
+            'budget': 30,
+            'planets': ['Earth', 'Jupiter', 'Mars', 'Mercury', 'Neptune', 'Saturn', 'Uranus', 'Venus']
+            }
+
+    data_as_json = json.dumps(data)
+    return HttpResponse(data_as_json, status=200, content_type='application/json')
 
 
 def battle_temp(request):  # does not require login (useful for FE tests)
@@ -109,53 +166,13 @@ def battle_temp(request):  # does not require login (useful for FE tests)
     battle_response = response.battle_final_report
     return HttpResponse(battle_response, status=200, content_type='application/json')
 
-
-# if the user is not logged in, they will be displayed an unauthorized message (401)
-#@login_required(login_url='/not_authenticated')
-def choose(request):
-    print(request.headers)
-    if not request.method == 'GET':
-        return HttpResponseBadRequest("Bad request")
-    ### test code ###
-    data = {'username': 'fake user',
-            'token': 'fake_142524523515fjgnjdgn',
-            'prices': {'S': 5, 'C': 2, 'D': 1},
-            "F": [1, 2, 3],
-            'budget': 30,
-            'planets': ['Earth', 'Jupiter', 'Mars', 'Mercury', 'Neptune', 'Saturn', 'Uranus', 'Venus']}
-            #################
-    data_as_json = json.dumps(data)
-    return HttpResponse(data_as_json, status=200, content_type='application/json')
-
-    user_auth = UserAuth(request)
-    '''
-    # print(request.user)
-    # note: the request.user value is always unique! Thus it can be directly used to retrieve token from db
-    '''
-    data = {'username': user_auth.username,
-            'token': user_auth.token,
-            'uid': user_auth.uid,
-            'prices': {"S": SpaceShip().price, "C": SpaceCruiser().price, "D": SpaceDestroyer().price},
-            "F": [1, 2, 3],
-            'budget': 30,
-            'planets': ['Earth', 'Jupiter', 'Mars', 'Mercury', 'Neptune', 'Saturn', 'Uranus', 'Venus']
-            }
-    data_as_json = json.dumps(data)
-    return HttpResponse(data_as_json, status=200, content_type='application/json')
-
-
-def choose_temp(request):  # does not require login (useful for FE tests)
-    data = {'username': "fake user",
-            'token': "abcd.FAKETOKENnafk48598258gnfmn43849gnfureufjjurjru383574n3jkf",
-            'prices': {"S": SpaceShip().price, "C": SpaceCruiser().price, "D": SpaceDestroyer().price},
-            "F": [1, 2, 3],
-            'budget': 30,
-            'planets': ['Earth', 'Jupiter', 'Mars', 'Mercury', 'Neptune', 'Saturn', 'Uranus', 'Venus']
-            }
-
-    data_as_json = json.dumps(data)
-    return HttpResponse(data_as_json, status=200, content_type='application/json')
-
-
-def not_authenticated(request):
-    return HttpResponse('not authorized: please sign in', status=401)
+# TEST_JSON = '{"winner":true,"army":{"S":0,"C":1,"D":2},"report":{"1":{"a":3,"d":1},"2":{"a":2,"d":1}}}'
+# input_fe = '{"attacker":{"type":"human",' \
+#           '"name":"player x",' \
+#           '"mail":"player@mail.com",' \
+#           '"army":{"S":24,"C":1,"D":1,"F":1},' \
+#           '"planet":"Venus"},' \
+#           '"defender":{"type":"virtual",' \
+#           '"name":"computer 1",' \
+#           '"army":{"S":7,"C":8,"D":9,"F":2},' \
+#           '"planet":"Mercury"}}'

--- a/battle/views.py
+++ b/battle/views.py
@@ -103,15 +103,15 @@ def choose(request):
     if not request.method == 'GET':
         return HttpResponseBadRequest("Bad request")
     ### test code ###
-    data = {'username': 'fake user',
-            'token': 'fake_142524523515fjgnjdgn',
-            'prices': {'S': 5, 'C': 2, 'D': 1},
-            "F": [1, 2, 3],
-            'budget': 30,
-            'planets': ['Earth', 'Jupiter', 'Mars', 'Mercury', 'Neptune', 'Saturn', 'Uranus', 'Venus']}
-            #################
-    data_as_json = json.dumps(data)
-    return HttpResponse(data_as_json, status=200, content_type='application/json')
+    # data = {'username': 'fake user',
+    #         'token': 'fake_142524523515fjgnjdgn',
+    #         'prices': {'S': 5, 'C': 2, 'D': 1},
+    #         "F": [1, 2, 3],
+    #         'budget': 30,
+    #         'planets': ['Earth', 'Jupiter', 'Mars', 'Mercury', 'Neptune', 'Saturn', 'Uranus', 'Venus']}
+    #         #################
+    # data_as_json = json.dumps(data)
+    # return HttpResponse(data_as_json, status=200, content_type='application/json')
 
     user_auth = UserAuth(request)
     '''

--- a/core/settings.py
+++ b/core/settings.py
@@ -171,7 +171,7 @@ STATIC_URL = '/static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 SITE_ID = 1
-LOGIN_REDIRECT_URL = 'https://browsergameteam2.netlify.app/battle__page'  # not official -> ./choose/
+LOGIN_REDIRECT_URL = '/choose/'  # not official -> ./choose/
 
 
 # Activate Django-Heroku

--- a/core/settings.py
+++ b/core/settings.py
@@ -171,7 +171,8 @@ STATIC_URL = '/static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 SITE_ID = 1
-LOGIN_REDIRECT_URL = 'https://browsergameteam2.netlify.app/battle__page'  # not official -> ./choose/
+LOGIN_REDIRECT_URL = '/oauth/'  # this triggers the view called user_logged_in_ where authentication data are retrieved and sent to FE
+
 
 # Activate Django-Heroku
 # django_heroku.settings(locals())

--- a/core/settings.py
+++ b/core/settings.py
@@ -171,8 +171,7 @@ STATIC_URL = '/static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 SITE_ID = 1
-LOGIN_REDIRECT_URL = '/choose/'  # not official -> ./choose/
-
+LOGIN_REDIRECT_URL = 'https://browsergameteam2.netlify.app'  # not official -> ./choose/
 
 # Activate Django-Heroku
 # django_heroku.settings(locals())

--- a/core/settings.py
+++ b/core/settings.py
@@ -171,7 +171,7 @@ STATIC_URL = '/static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 SITE_ID = 1
-LOGIN_REDIRECT_URL = 'https://modest-almeida-b3a50e.netlify.app/battle__page'  # not official -> ./choose/
+LOGIN_REDIRECT_URL = 'https://browsergameteam2.netlify.app/battle__page'  # not official -> ./choose/
 
 
 # Activate Django-Heroku

--- a/core/settings.py
+++ b/core/settings.py
@@ -171,7 +171,7 @@ STATIC_URL = '/static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 SITE_ID = 1
-LOGIN_REDIRECT_URL = 'https://browsergameteam2.netlify.app'  # not official -> ./choose/
+LOGIN_REDIRECT_URL = 'https://browsergameteam2.netlify.app/battle__page'  # not official -> ./choose/
 
 # Activate Django-Heroku
 # django_heroku.settings(locals())

--- a/core/settings.py
+++ b/core/settings.py
@@ -42,7 +42,7 @@ SOCIALACCOUNT_PROVIDERS = \
 SECRET_KEY = env.str("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = env.bool("DEBUG", default=False)
+DEBUG = env.bool("DEBUG", default=True)
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
handling the google auth data:
currently after the google oauth a django view is triggered and there is a redirect INSIDE that view,
by appending the retrieved token to the FE url (not best practice but temporary solution)